### PR TITLE
python-zstd 1.5.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1ef980abf0e1e072b028d2d76ef95b476632651c96225cf30b619c6eef625672
 
 build:
-  number: 0
+  number: 2
   script:
     - export ZSTD_EXTERNAL=1  # [not win]
     - set ZSTD_EXTERNAL=1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,22 +10,22 @@ source:
   sha256: 1ef980abf0e1e072b028d2d76ef95b476632651c96225cf30b619c6eef625672
 
 build:
-  number: 2
+  number: 0
   script:
     - export ZSTD_EXTERNAL=1  # [not win]
     - set ZSTD_EXTERNAL=1  # [win]
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  
+
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib("c") }}
     - pkg-config
   host:
     - python
     - setuptools
     - pip
     - zstd
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,14 @@ test:
 about:
   home: https://github.com/sergey-dryabzhinsky/python-zstd
   summary: ZSTD Bindings for Python
+  description: |
+    Zstd, short for Zstandard, is a new lossless compression algorithm,
+    which provides both good compression ratio and speed for your standard compression needs.
   license: BSD-2-Clause
   license_file: LICENSE
+  license_family: BSD
+  dev_url: https://github.com/sergey-dryabzhinsky/python-zstd
+  doc_url: https://github.com/sergey-dryabzhinsky/python-zstd
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5930](https://anaconda.atlassian.net/browse/PKG-5930)
- [Upstream repository](https://github.com/sergey-dryabzhinsky/python-zstd/tree/v1.5.5.1)
- [Upstream changelog/diff](https://github.com/sergey-dryabzhinsky/python-zstd/releases)
- Relevant dependency PRs:
  - python-zstd > asynch > clickhouse-sqlalchemy

### Explanation of changes:

- Initialize feedstock
- Bring recipe up to our standards


[PKG-5930]: https://anaconda.atlassian.net/browse/PKG-5930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ